### PR TITLE
Implemented support for multiple semesters

### DIFF
--- a/frontend/src/components/app/storage.ts
+++ b/frontend/src/components/app/storage.ts
@@ -49,7 +49,7 @@ export async function createSchedule(): Promise<Schedule> {
     let stored = localStorage.getItem("totalCreated");
     let n = (stored) ? parseInt(stored) : 0;
 
-    let semester: string = await axios.get("http://api.scheduleterp.com/latest-semester")
+    let semester: string = await axios.get("https://api.scheduleterp.com/latest-semester")
                     .then(resp => resp.data.latest ?? alert("Error: Couldn't determine semester"))
                     .catch(err => {
                         console.error(err);

--- a/frontend/src/components/controlpanel/ControlPanel.tsx
+++ b/frontend/src/components/controlpanel/ControlPanel.tsx
@@ -65,7 +65,7 @@ function ControlPanel() {
                             })
 
                             axios.post("https://api.scheduleterp.com/schedule/upload", {
-                                semester: "202508",
+                                semester: appContext?.currentSchedSem,
                                 sections,
                                 colors: sections?.map((sec) => appContext?.colorMap[sec])
                             }).then((resp) => {
@@ -100,12 +100,13 @@ function ControlPanel() {
                     <i
                         className={`${styles.addBtn} fa-solid fa-plus`}
                         onClick={() => {
-                            let sched = createSchedule();
-                            let id = sched.id;
+                            createSchedule().then(sched => {
+                                let id = sched.id;
 
-                            saveSchedule(sched);
-                            appContext?.setCurrentScheduleID(id);
-                            setNameDropdownToggle(true);
+                                saveSchedule(sched);
+                                appContext?.setCurrentScheduleID(id);
+                                setNameDropdownToggle(true);
+                            });
                         }}></i>
                 </div>
                 <Collapse className={styles.otherSchedulesContainer} in={nameDropdownToggled}>

--- a/frontend/src/components/courselist/CourseList.tsx
+++ b/frontend/src/components/courselist/CourseList.tsx
@@ -86,7 +86,7 @@ let CourseList: CourseListComponent = ({
     }
     const handler = setTimeout(async () => {
       // this is running with selectedSections from initial prob
-      let res = await api.get(`https://api.scheduleterp.com/search/202508`, {
+      let res = await api.get(`https://api.scheduleterp.com/search/${appContext?.currentSchedSem}`, {
         params: { query: appContext?.searchVal },
       });
 

--- a/frontend/src/components/courselist/CourseResult.tsx
+++ b/frontend/src/components/courselist/CourseResult.tsx
@@ -4,8 +4,9 @@ import { Section } from "../../types/api";
 import { CourseResultComponent } from "./courselist.types";
 import SectionResult from "./SectionResult";
 import { Collapse } from "@mantine/core";
-import { useState } from "react";
+import { useContext, useState } from "react";
 import toast from "react-hot-toast";
+import { AppContext } from "../app/App";
 
 const CourseResult: CourseResultComponent = ({
   course,
@@ -28,6 +29,8 @@ const CourseResult: CourseResultComponent = ({
     
   };
 
+  let appContext = useContext(AppContext);
+
   let [expanded, setExpanded] = useState(false);
 
   return (
@@ -35,7 +38,7 @@ const CourseResult: CourseResultComponent = ({
       <div className={styles.courseInfo}>
         <div className={styles.courseHeader}>
           <span className={styles.courseID} title="View on Testudo">
-            <a href={`https://app.testudo.umd.edu/soc/search?courseId=${course._id}&sectionId=&termId=202508&_openSectionsOnly=on&creditCompare=&credits=&courseLevelFilter=ALL&instructor=&_facetoface=on&_blended=on&_online=on&courseStartCompare=&courseStartHour=&courseStartMin=&courseStartAM=&courseEndHour=&courseEndMin=&courseEndAM=&teachingCenter=ALL&_classDay1=on&_classDay2=on&_classDay3=on&_classDay4=on&_classDay5=on`}
+            <a href={`https://app.testudo.umd.edu/soc/search?courseId=${course._id}&sectionId=&termId=${appContext?.currentSchedSem}&_openSectionsOnly=on&creditCompare=&credits=&courseLevelFilter=ALL&instructor=&_facetoface=on&_blended=on&_online=on&courseStartCompare=&courseStartHour=&courseStartMin=&courseStartAM=&courseEndHour=&courseEndMin=&courseEndAM=&teachingCenter=ALL&_classDay1=on&_classDay2=on&_classDay3=on&_classDay4=on&_classDay5=on`}
               target="_blank" rel="noopener noreferrer"
             >
               {course._id}

--- a/frontend/src/components/courselist/SectionResult.tsx
+++ b/frontend/src/components/courselist/SectionResult.tsx
@@ -47,7 +47,7 @@ const SectionResult: SectionResultComponent = ({
 
     res.reverse().forEach((res) =>
       res.then((res) => {
-        res.gpa ? setGPA(res.gpa) : null;
+        res.gpa ? setGPA(res.gpa) : setGPA(null);
       })
     );
 

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -52,6 +52,7 @@ export interface TimeBlock {
 export interface Schedule {
   id: string;
   name: string;
+  semester: string;
   sections: [Course, Section][];
   colorMap: {[section: string]: number};
 }


### PR DESCRIPTION
Fall 2025 was hardcoded as the semester in a few places. Reworked the frontend to always create schedules in the latest semester. 

Schedules from previous semesters should still work properly whether they're loaded from local storage or a share link.

Changed the default naming scheme of new schedules to be "<Term> <Year> [<number>]"
